### PR TITLE
added missing slash to workspace path

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -806,7 +806,7 @@ class Catalog:
             path_parts = "layergroups/{}.xml".format(name)
             if workspace is not None:
                 wks_name = _name(workspace)
-                path_parts = "workspaces/{}".format(wks_name) + path_parts
+                path_parts = "workspaces/{}/{}".format(wks_name, path_parts)
             group_url = urljoin(
                 self.service_url,
                 path_parts


### PR DESCRIPTION
catalog.get_layergroup('my_layer', 'my_workspace')
fails due to missing slash in path

Tried to make a GET request to http://localhost:8080/geoserver/rest/workspaces/my_workspacelayergroups/my_layer.xml but got a 404 status code:

<html>

<head>

<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>

<title>Error 404 Not Found</title>

</head>

<body><h2>HTTP ERROR 404</h2>

<p>Problem accessing /geoserver/rest/workspaces/ my_workspacelayergroups/ my_layer.xml. Reason:

<pre>    Not Found</pre></p><hr><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.4.18.v20190429</a><hr/>


</body>

</html>